### PR TITLE
Use caret for composer/installers dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 	"homepage": "https://github.com/chinpei215/cakephp-eager-loader",
 	"license": "MIT",
 	"require": {
-		"composer/installers": "*"
+		"composer/installers": "^1.0.23"
 	},
 	"extra": {
 		"installer-name": "EagerLoader"


### PR DESCRIPTION
https://getcomposer.org/doc/articles/versions.md

Also use version 1.0.23 and upwards to fix API deprecation warning https://github.com/composer/installers/releases/tag/v1.0.23
